### PR TITLE
Fix road sprite stop frame

### DIFF
--- a/structures/roads.sprite
+++ b/structures/roads.sprite
@@ -4,7 +4,7 @@
 	<imagesheet id="destroyed" src="destroyed.png" />
 
 	<action name="construction">
-		<frame sheetid="construction" delay="0" x="0" y="0" width="128" height="128" anchorx="0" anchory="64" />
+		<frame sheetid="construction" x="0" y="0" width="128" height="128" anchorx="0" anchory="64" />
 	</action>
 
 	<action name="operational">

--- a/structures/roads.sprite
+++ b/structures/roads.sprite
@@ -4,7 +4,7 @@
 	<imagesheet id="destroyed" src="destroyed.png" />
 
 	<action name="construction">
-		<frame sheetid="construction" delay="-1" x="0" y="0" width="128" height="128" anchorx="0" anchory="64" />
+		<frame sheetid="construction" delay="0" x="0" y="0" width="128" height="128" anchorx="0" anchory="64" />
 	</action>
 
 	<action name="operational">


### PR DESCRIPTION
The stop frame sentinel value was changed from `-1` to `0` a long while back. Both values would have no real meaning for the frame `delay`. Though since the `delay` field is `unsigned`, a value of `0` is more natural for a sentinel value. In particular, it avoids exceptions with some of the range checks that are now in place.

The default value for `delay` is now `0`, so not specifying the field will result in a stop frame.

Fixes a "Value out of range: -1" exception when constructing `Road` objects, which triggered loading of the `Sprite` and processing the XML file, and failing on the `delay` value.
