### PR TITLE
Add "Null" entry to `StructureTypes.xml`

### DIFF
--- a/StructureTypes.xml
+++ b/StructureTypes.xml
@@ -1,5 +1,34 @@
 <Structures>
 	<Structure
+		Name="Null"
+		ImagePath=""
+		TurnsToBuild="0"
+		MaxAge="0"
+		EnergyRequired="0"
+		EnergyProduced="0"
+		FoodProduced="0"
+		FoodStorageCapacity="0"
+		OreStorageCapacity="0"
+		IntegrityDecayRate="1"
+		RequiredWorkers="0"
+		RequiredScientists="0"
+		IsSelfSustained="false"
+		IsRepairable="true"
+		IsChapRequired="true"
+		IsCrimeTarget="false"
+		Priority="0">
+		<BuildCost
+			resource_0="0"
+			resource_1="0"
+			resource_2="0"
+			resource_3="0" />
+		<OperationalCost
+			resource_0="0"
+			resource_1="0"
+			resource_2="0"
+			resource_3="0" />
+	</Structure>
+	<Structure
 		Name="Agricultural Dome"
 		ImagePath="structures/agridome.sprite"
 		TurnsToBuild="3"


### PR DESCRIPTION
A "Null" entry can be used to take up the slot at index `0`. That allows the `StructureType` index values to correspond with the `StrctureID` enum values. Potentially we can `static_cast` between `structureTypeIndex` values and `StructureID` enum values.

Additionally, having a null entry would allow us a place to list all available properties that can be set, and the default values of those properties. The defaults are currently hardcoded. Potentially the null entry could serve as a source for those defaults, or at least documentation as to what they are.

On a related note, we can potentially remove properties from `StructureType` entries when they are set to the default value. When the file was generated, all properties were always listed, even if they were default values for a field that `StructureType` didn't expect to use.

----

Related:
- Issue https://github.com/OutpostUniverse/OPHD/issues/1723
- https://github.com/OutpostUniverse/OPHD/issues/1804
