### PR TITLE
Add `construction` and `operation` actions to `Tube` and `AirShaft`

### DIFF
--- a/structures/air_shaft.sprite
+++ b/structures/air_shaft.sprite
@@ -2,6 +2,10 @@
 	<imagesheet id="main" src="air_shaft.png" />
 	<imagesheet id="destroyed" src="destroyed.png" />
 
+	<action name="construction">
+		<frame sheetid="main" x="0" y="0" width="128" height="128" anchorx="0" anchory="64" />
+	</action>
+
 	<action name="operational">
 		<frame sheetid="main" x="0" y="0" width="128" height="128" anchorx="0" anchory="64" />
 	</action>

--- a/structures/air_shaft_ug.sprite
+++ b/structures/air_shaft_ug.sprite
@@ -2,6 +2,10 @@
 	<imagesheet id="main" src="air_shaft_ug.png" />
 	<imagesheet id="destroyed" src="destroyed.png" />
 
+	<action name="construction">
+		<frame sheetid="main" x="0" y="0" width="128" height="128" anchorx="0" anchory="64" />
+	</action>
+
 	<action name="operational">
 		<frame sheetid="main" x="0" y="0" width="128" height="128" anchorx="0" anchory="64" />
 	</action>

--- a/structures/tubes.sprite
+++ b/structures/tubes.sprite
@@ -1,6 +1,15 @@
 <sprite version="0.99">
 	<imagesheet id="main" src="tubes.png" />
 
+	<action name="construction">
+		<frame sheetid="main" x="0" y="0" width="128" height="64" anchorx="0" anchory="0" />
+	</action>
+
+	<action name="operational">
+		<frame sheetid="main" x="0" y="0" width="128" height="64" anchorx="0" anchory="0" />
+	</action>
+
+
 	<action name="intersection">
 		<frame sheetid="main" x="0" y="0" width="128" height="64" anchorx="0" anchory="0" />
 	</action>

--- a/structures/tubes_ug.sprite
+++ b/structures/tubes_ug.sprite
@@ -1,6 +1,15 @@
 <sprite version="0.99">
 	<imagesheet id="main" src="tubes.png" />
 
+	<action name="construction">
+		<frame sheetid="main" x="0" y="64" width="128" height="64" anchorx="0" anchory="0" />
+	</action>
+
+	<action name="operational">
+		<frame sheetid="main" x="0" y="64" width="128" height="64" anchorx="0" anchory="0" />
+	</action>
+
+
 	<action name="intersection">
 		<frame sheetid="main" x="0" y="64" width="128" height="64" anchorx="0" anchory="0" />
 	</action>


### PR DESCRIPTION
This increases consistency in available `action` fields. There is now a standard set of `action` values that are the same for all `Structure` types. This allows for removing some special case code and error checking, increasing consistency between `Structure` types.

Related:
- Issue https://github.com/OutpostUniverse/OPHD/issues/1804
